### PR TITLE
Adds geobalanced public node rpc.nodes.rentals.

### DIFF
--- a/src-electron/main-process/modules/backend.js
+++ b/src-electron/main-process/modules/backend.js
@@ -122,6 +122,10 @@ export class Backend {
             {
                 host: "nodes.hashvault.pro",
                 port: "22023"
+            },
+            {
+                host: "rpc.nodes.rentals",
+                port: "22023"
             }
         ]
 


### PR DESCRIPTION
Automatic geobalancing at the DNS query level based on the country / continent of the person connecting to the servers.