### PR TITLE
Wallet improvements

### DIFF
--- a/src-electron/main-process/modules/wallet-rpc.js
+++ b/src-electron/main-process/modules/wallet-rpc.js
@@ -613,9 +613,11 @@ export class WalletRPC {
 
     heartbeatAction (extended = false) {
         Promise.all([
+            this.sendRPC("get_address", { account_index: 0 }, 5000),
             this.sendRPC("getheight", {}, 5000),
             this.sendRPC("getbalance", { account_index: 0 }, 5000)
         ]).then((data) => {
+            let didError = false
             let wallet = {
                 status: {
                     code: 0,
@@ -634,10 +636,15 @@ export class WalletRPC {
                     address_book: [],
                     address_book_starred: []
                 }
-
             }
+
             for (let n of data) {
                 if (n.hasOwnProperty("error") || !n.hasOwnProperty("result")) {
+                    // Maybe we also need to look into the other error codes it could give us
+                    // Error -13: No wallet file - This occurs when you call open wallet while another wallet is still syncing
+                    if (extended && n.error && n.error.code === -13) {
+                        didError = true
+                    }
                     continue
                 }
 
@@ -646,6 +653,13 @@ export class WalletRPC {
                     this.sendGateway("set_wallet_data", {
                         info: {
                             height: n.result.height
+                        }
+                    })
+                } else if (n.method == "get_address") {
+                    wallet.info.address = n.result.address
+                    this.sendGateway("set_wallet_data", {
+                        info: {
+                            address: n.result.address
                         }
                     })
                 } else if (n.method == "getbalance") {
@@ -675,6 +689,17 @@ export class WalletRPC {
                             })
                         }
                         this.sendGateway("set_wallet_data", wallet)
+                    })
+                }
+            }
+
+            // Set the wallet state on initial heartbeat
+            if (extended) {
+                if (!didError) {
+                    this.sendGateway("set_wallet_data", wallet)
+                } else {
+                    this.closeWallet().then(() => {
+                        this.sendGateway("set_wallet_error", { status: { code: -1, message: "Failed to open wallet. Please try again." } })
                     })
                 }
             }
@@ -1512,7 +1537,7 @@ export class WalletRPC {
         if (Object.keys(params).length !== 0) {
             options.json.params = params
         }
-        if (timeout) {
+        if (timeout > 0) {
             options.timeout = timeout
         }
 

--- a/src-electron/main-process/modules/wallet-rpc.js
+++ b/src-electron/main-process/modules/wallet-rpc.js
@@ -139,7 +139,7 @@ export class WalletRPC {
                                 }
                             }
 
-                            // Keep track on wether a wallet is sycning or not
+                            // Keep track on wether a wallet is syncing or not
                             this.sendGateway("set_wallet_data", { isRPCSyncing })
                             this.isRPCSyncing = isRPCSyncing
 
@@ -1353,12 +1353,6 @@ export class WalletRPC {
         }
 
         fs.readdirSync(this.wallet_dir).forEach(filename => {
-            if (filename.endsWith(".keys") ||
-               filename.endsWith(".meta.json") ||
-               filename.endsWith(".address.txt") ||
-               filename.endsWith(".bkp-old") ||
-               filename.endsWith(".unportable")) { return }
-
             switch (filename) {
             case ".DS_Store":
             case ".DS_Store?":
@@ -1385,6 +1379,9 @@ export class WalletRPC {
                 }
                 return
             }
+
+            // Exclude all files with an extension
+            if (path.extname(filename) !== "") return
 
             let wallet_data = {
                 name: filename,

--- a/src/components/mainmenu.vue
+++ b/src/components/mainmenu.vue
@@ -86,6 +86,7 @@ export default {
     },
     computed: mapState({
         theme: state => state.gateway.app.config.appearance.theme,
+        isRPCSyncing: state => state.gateway.wallet.isRPCSyncing,
     }),
     methods: {
         openExternal (url) {
@@ -101,6 +102,13 @@ export default {
             this.$refs.settingsModal.isVisible = true
         },
         switchWallet () {
+            // If the rpc is syncing then we want to tell the user to restart
+            if (this.isRPCSyncing) {
+                this.$gateway.confirmClose("The wallet RPC is currently syncing. If you wish to switch wallets then you must restart the application. You will lose your syncing progress and have to rescan the blockchain again.", true)
+                return
+            }
+
+            // Allow switching normally because rpc won't be blocked
             this.$q.dialog({
                 title: "Switch wallet",
                 message: "Are you sure you want to close the current wallet?",

--- a/src/store/gateway/state.js
+++ b/src/store/gateway/state.js
@@ -49,7 +49,8 @@ export default {
             used: [],
             unused: [],
             address_book: []
-        }
+        },
+        isRPCSyncing: false
     },
     tx_status: {
         code: 0,


### PR DESCRIPTION
This PR improves wallet UX.

- Instantly open up wallets and lazy load rest of the information
    - This may solve some of the infinite loading issues
- If a user switches wallet while the wallet rpc is syncing, then we prompt them to restart the application
    - If wallet rpc is syncing then any rpc call is blocked until syncing has finished. This causes multiple ux issues.
    - One such issue is that of infinite loading wallet. If we switch a wallet while the rpc is syncing and then we try open another wallet, users thinks it's infinitely loading but in reality the rpc is blocked and thus we are waiting for it to be unblocked.
- Show an error if wallet failed to open. This would occur when you open a wallet while the rpc was blocked.
- Fix wallet list showing non wallet files
