### PR TITLE
Fix atomic value calculation for stake/transfer

### DIFF
--- a/src-electron/main-process/modules/wallet-rpc.js
+++ b/src-electron/main-process/modules/wallet-rpc.js
@@ -744,7 +744,7 @@ export class WalletRPC {
                 return
             }
 
-            amount = parseFloat(amount).toFixed(9) * 1e9
+            amount = (parseFloat(amount) * 1e9).toFixed(0)
 
             this.sendRPC("stake", {
                 amount,
@@ -914,7 +914,7 @@ export class WalletRPC {
                 return
             }
 
-            amount = parseFloat(amount).toFixed(9) * 1e9
+            amount = (parseFloat(amount) * 1e9).toFixed(0)
 
             let sweep_all = amount == this.wallet_state.unlocked_balance
 


### PR DESCRIPTION
The logic underlying the conversion of input value into atomic value was
wrong: for some values, `parseFloat(amount).toFixed(9) * 1e9` doesn't
result in an integer because of numeric imprecision, and so a
non-integer value gets passed into the RPC wallet which chokes on it.

For example:

```Javascript
    ((parseFloat("17199.899334361")).toFixed(9)*1e9).toString()
```

gives

```Javascript
    17199899334360.998
```

This fixes the code to multiply by 1e9 *before* rounding to an atomic
unit so that we always get an integer value.