### PR TITLE
Disable higher priorities (temporary until v5)

### DIFF
--- a/src/pages/wallet/send.vue
+++ b/src/pages/wallet/send.vue
@@ -165,8 +165,8 @@ export default {
                 {label: this.$t("strings.priorityOptions.automatic"), value: 0},
                 {label: this.$t("strings.priorityOptions.slow"), value: 1},
                 {label: this.$t("strings.priorityOptions.normal"), value: 2},
-                {label: this.$t("strings.priorityOptions.fast"), value: 3},
-                {label: this.$t("strings.priorityOptions.fastest"), value: 4},
+//                {label: this.$t("strings.priorityOptions.fast"), value: 3},
+//                {label: this.$t("strings.priorityOptions.fastest"), value: 4},
             ],
         }
     },


### PR DESCRIPTION
Loki priorities are stupidly high at priority 3 or 4; this disables them temporarily.