### PR TITLE
Refactor auto updating

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,3 +5,7 @@ charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.js]
+indent_size = 2
+indent_style = space

--- a/package-lock.json
+++ b/package-lock.json
@@ -6447,14 +6447,6 @@
         }
       }
     },
-    "electron-progressbar": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/electron-progressbar/-/electron-progressbar-1.2.0.tgz",
-      "integrity": "sha512-I89HaI61SF5wl8c4p62UU3RXhL0xByzl4XH/miwb1e/VNUtRj5WCe/wJ5pNikfC01+/4aAOlNsbmkfsvQjtW6Q==",
-      "requires": {
-        "extend": "^3.0.1"
-      }
-    },
     "electron-publish": {
       "version": "22.2.0",
       "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-22.2.0.tgz",
@@ -6839,6 +6831,16 @@
           "requires": {
             "parent-module": "^1.0.0",
             "resolve-from": "^4.0.0"
+          }
+        },
+        "js-yaml": {
+          "version": "3.13.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         },
         "ms": {
@@ -7328,7 +7330,8 @@
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -10048,16 +10051,6 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
-    },
-    "js-yaml": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
-      "dev": true,
-      "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      }
     },
     "jsbn": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "axios": "^0.18.1",
     "electron-is-dev": "^1.0.1",
-    "electron-progressbar": "^1.2.0",
     "electron-updater": "^4.2.0",
     "electron-window-state": "^5.0.3",
     "flag-icon-css": "^3.3.0",

--- a/src-electron/main-process/auto-updater.js
+++ b/src-electron/main-process/auto-updater.js
@@ -1,89 +1,91 @@
 import { dialog } from "electron";
 import isDev from "electron-is-dev";
 import { autoUpdater } from "electron-updater";
-import ProgressBar from "electron-progressbar";
 
-let progressBar = null;
 let isUpdating = false;
-let downloadAndInstall = false;
 
-function checkForUpdate(onQuitAndInstall) {
+async function checkForUpdate(getMainWindow, onQuitAndInstall) {
   // Disable for development
   if (isDev) {
     return;
   }
 
+  if (isUpdating) {
+    return;
+  }
+
   autoUpdater.logger = console;
-  autoUpdater.autoDownload = false;
 
-  autoUpdater.on("error", err => {
-    if (isUpdating) {
-      dialog.showErrorBox("Update Error: ", err == null ? "unknown" : err.message);
-      isUpdating = false;
-      console.error("Error in auto-updater.", err.message);
-    }
-  });
+  try {
+    // Get the update using electron-updater
+    try {
+      const info = await autoUpdater.checkForUpdates();
+      if (!info.downloadPromise) {
+        console.info("auto-update: no update to download");
 
-  autoUpdater.on("update-available", info => {
-    console.log(`Update available: ${info.version}`);
-
-    const message = `Update ${info.version} found. Do you want to download the update?`;
-    const detail = `View the release notes at: https://github.com/loki-project/loki-electron-gui-wallet/releases/tag/v${info.version}`;
-
-    dialog.showMessageBox(
-      {
-        type: "info",
-        title: "Update available",
-        message,
-        detail,
-        buttons: ["Download and Install", "Download and Install Later", "No"],
-        defaultId: 0
-      },
-      buttonIndex => {
-        // Download and install
-        if (buttonIndex === 0) {
-          downloadAndInstall = true;
-          if (!progressBar) {
-            progressBar = new ProgressBar({
-              indeterminate: false,
-              title: "Downloading...",
-              text: `Downloading wallet v${info.version}`
-            });
-          }
-        }
-
-        // Download
-        if (buttonIndex !== 2) {
-          isUpdating = true;
-          autoUpdater.downloadUpdate();
-        }
+        return;
       }
-    );
-  });
-
-  autoUpdater.on("download-progress", progress => {
-    if (progressBar) {
-      progressBar.value = progress.percent;
-    }
-  });
-
-  autoUpdater.on("update-downloaded", () => {
-    console.log("Update downloaded");
-    isUpdating = false;
-
-    if (progressBar) {
-      progressBar.setCompleted();
-      progressBar = null;
+      await info.downloadPromise;
+    } catch (error) {
+      await showCannotUpdateDialog(getMainWindow());
+      throw error;
     }
 
-    // If download and install was selected then quit and install
-    if (downloadAndInstall && onQuitAndInstall) {
+    // Update downloaded successfully, we should ask the user to update
+    console.info("auto-update: showing update dialog...");
+    const shouldUpdate = await showUpdateDialog(getMainWindow());
+    if (!shouldUpdate) {
+      return;
+    }
+
+    console.info("auto-update: calling quitAndInstall...");
+    if (onQuitAndInstall) {
       onQuitAndInstall(autoUpdater);
-      downloadAndInstall = false;
     }
-  });
+  } catch (error) {
+    console.error("auto-update error:", getPrintableError(error));
+  } finally {
+    isUpdating = false;
+  }
+}
 
-  autoUpdater.checkForUpdates();
+function getPrintableError(error) {
+  return error && error.stack ? error.stack : error;
+}
+
+async function showUpdateDialog(mainWindow) {
+  const RESTART_BUTTON = 0;
+  const LATER_BUTTON = 1;
+  const options = {
+    type: "info",
+    buttons: ["Restart Wallet", "Later"],
+    title: "Loki Electron Wallet update available",
+    message: "There is a new version of Loki Electron Wallet available.",
+    detail: "Press Restart Wallet to apply the update",
+    defaultId: LATER_BUTTON,
+    cancelId: RESTART_BUTTON
+  };
+  return new Promise(resolve => {
+    dialog.showMessageBox(mainWindow, options, response => {
+      resolve(response === RESTART_BUTTON);
+    });
+  });
+}
+
+async function showCannotUpdateDialog(mainWindow) {
+  const options = {
+    type: "error",
+    buttons: ["Ok"],
+    title: "Cannot update",
+    message:
+      "Loki Electron Wallet failed to update but there is a new version available. Please go to https://loki.network/ and install the new version manually."
+  };
+
+  return new Promise(resolve => {
+    dialog.showMessageBox(mainWindow, options, () => {
+      resolve();
+    });
+  });
 }
 
 export { checkForUpdate };

--- a/src-electron/main-process/electron-main.js
+++ b/src-electron/main-process/electron-main.js
@@ -155,18 +155,21 @@ function createWindow() {
 }
 
 app.on("ready", () => {
-  checkForUpdate(autoUpdater => {
-    if (mainWindow) {
-      mainWindow.webContents.send("showQuitScreen");
-    }
+  checkForUpdate(
+    () => mainWindow,
+    autoUpdater => {
+      if (mainWindow) {
+        mainWindow.webContents.send("showQuitScreen");
+      }
 
-    const promise = backend ? backend.quit() : Promise.resolve();
-    promise.then(() => {
-      installUpdate = true;
-      backend = null;
-      autoUpdater.quitAndInstall();
-    });
-  });
+      const promise = backend ? backend.quit() : Promise.resolve();
+      promise.then(() => {
+        installUpdate = true;
+        backend = null;
+        autoUpdater.quitAndInstall();
+      });
+    }
+  );
   if (process.platform === "darwin") {
     const menu = Menu.buildFromTemplate(menuTemplate);
     Menu.setApplicationMenu(menu);


### PR DESCRIPTION
Made it so we always download the new wallet update. There shouldn't be a reason for anyone to be on an older version.

The cannot update dialog has also been updated to include a link to the new wallet in the case that user wants to manually update.