### PR TITLE
Fix decrypt of session name and lokinet lns names

### DIFF
--- a/src/components/lns/lns_records.vue
+++ b/src/components/lns/lns_records.vue
@@ -52,7 +52,7 @@
 <script>
 import { mapState } from "vuex";
 import LokiField from "components/loki_field";
-import { session_id_or_lokinet_name } from "src/validators/common";
+import { session_name_or_lokinet_name } from "src/validators/common";
 import LNSRecordList from "./lns_record_list";
 
 export default {
@@ -182,7 +182,7 @@ export default {
 
   validations: {
     name: {
-      session_id_or_lokinet_name
+      session_name_or_lokinet_name
     }
   }
 };

--- a/src/validators/common.js
+++ b/src/validators/common.js
@@ -54,8 +54,8 @@ export const lokinet_name = (input, lokiExt = false) => {
   );
 };
 
-export const session_id_or_lokinet_name = input => {
-  return session_id(input) || lokinet_name(input, true);
+export const session_name_or_lokinet_name = input => {
+  return session_name(input) || lokinet_name(input, true);
 };
 
 // Full lokinet address


### PR DESCRIPTION
Fixes issue trying to decrypt name, where it says "may only contain alphanumerics, hyphens and underscores".