### PR TITLE
Don't do a full get_transfer every 5 seconds

### DIFF
--- a/src-electron/main-process/modules/wallet-rpc.js
+++ b/src-electron/main-process/modules/wallet-rpc.js
@@ -917,7 +917,7 @@ export class WalletRPC {
             this.wallet_state.balance == n.result.balance &&
             this.wallet_state.unlocked_balance == n.result.unlocked_balance
           ) {
-            // continue
+            continue;
           }
 
           this.wallet_state.balance = wallet.info.balance = n.result.balance;


### PR DESCRIPTION
There is code here to skip it if the balance hasn't changed, but it is
suspiciously commented out (and according to git blame has been that way
for a very long time).  On large wallets this is causing massive CPU
usage, wallet lag, and may be responsible for the balance update and
no-staked-nodes issues.