### PR TITLE
Remove payment ids from address book entries

### DIFF
--- a/src-electron/main-process/modules/daemon.js
+++ b/src-electron/main-process/modules/daemon.js
@@ -476,9 +476,6 @@ export class Daemon {
       if (!data.hasOwnProperty("result")) return;
       const nodes = data.result.service_node_states;
 
-      this.backend.log.info(
-        "Number of service nodes returned from RPC: " + nodes.length
-      );
       const service_nodes = {
         nodes,
         fetching: false

--- a/src-electron/main-process/modules/wallet-rpc.js
+++ b/src-electron/main-process/modules/wallet-rpc.js
@@ -390,7 +390,6 @@ export class WalletRPC {
       case "add_address_book":
         this.addAddressBook(
           params.address,
-          params.payment_id,
           params.description,
           params.name,
           params.starred,
@@ -1489,11 +1488,9 @@ export class WalletRPC {
   async relayTransaction(metadataList, isBlink, addressSave, note, isSweepAll) {
     // for a sweep these don't exist
     let address = "";
-    let payment_id = "";
     let address_book = "";
     if (addressSave) {
       address = addressSave.address;
-      payment_id = addressSave.payment_id;
       address_book = addressSave.address_book;
     }
 
@@ -1545,7 +1542,6 @@ export class WalletRPC {
       if (address_book.hasOwnProperty("save") && address_book.save) {
         this.addAddressBook(
           address,
-          payment_id,
           address_book.description,
           address_book.name
         );
@@ -2157,12 +2153,6 @@ export class WalletRPC {
             entry.description = "";
           }
 
-          if (/^0*$/.test(entry.payment_id)) {
-            entry.payment_id = "";
-          } else if (/^0*$/.test(entry.payment_id.substring(16))) {
-            entry.payment_id = entry.payment_id.substring(0, 16);
-          }
-
           return entry;
         });
 
@@ -2171,11 +2161,7 @@ export class WalletRPC {
             ? wallet.address_list.address_book_starred
             : wallet.address_list.address_book;
           const hasAddress = list.find(a => {
-            return (
-              a.address === entry.address &&
-              a.name === entry.name &&
-              a.payment_id === entry.payment_id
-            );
+            return a.address === entry.address && a.name === entry.name;
           });
           if (!hasAddress) {
             list.push(entry);
@@ -2201,7 +2187,6 @@ export class WalletRPC {
 
   addAddressBook(
     address,
-    payment_id = null,
     description = "",
     name = "",
     starred = false,
@@ -2209,7 +2194,7 @@ export class WalletRPC {
   ) {
     if (index !== false) {
       this.sendRPC("delete_address_book", { index: index }).then(() => {
-        this.addAddressBook(address, payment_id, description, name, starred);
+        this.addAddressBook(address, description, name, starred);
       });
       return;
     }
@@ -2217,9 +2202,6 @@ export class WalletRPC {
     let params = {
       address
     };
-    if (payment_id != null) {
-      params.payment_id = payment_id;
-    }
 
     let desc = [];
     if (starred) {

--- a/src-electron/main-process/modules/wallet-rpc.js
+++ b/src-electron/main-process/modules/wallet-rpc.js
@@ -916,7 +916,6 @@ export class WalletRPC {
             this.wallet_state.balance == n.result.balance &&
             this.wallet_state.unlocked_balance == n.result.unlocked_balance
           ) {
-            this.backend.log.info("Your balance is unchanged");
             continue;
           }
 
@@ -930,7 +929,6 @@ export class WalletRPC {
           // if balance has recently changed, get updated list of transactions and used addresses
           let actions = [this.getTransactions(), this.getAddressList()];
           actions.push(this.getAddressBook());
-          this.backend.log.info("Begin to get transactions and address list");
           Promise.all(actions).then(data => {
             for (let n of data) {
               Object.keys(n).map(key => {
@@ -2058,12 +2056,7 @@ export class WalletRPC {
         failed: true,
         pool: true
       }).then(data => {
-        this.backend.log.info("get_transfers callback running");
         if (data.hasOwnProperty("error") || !data.hasOwnProperty("result")) {
-          this.backend.log.info(
-            "get_transfers did not return a result, or returned an error"
-          );
-          this.backend.log.info(data);
           resolve({});
           return;
         }
@@ -2086,10 +2079,6 @@ export class WalletRPC {
         ];
         types.forEach(type => {
           if (data.result.hasOwnProperty(type)) {
-            const txs_of_type_len = data.result[type].length;
-            this.backend.log.info(
-              `Number of txs of type ${type}: ${txs_of_type_len}`
-            );
             wallet.transactions.tx_list = wallet.transactions.tx_list.concat(
               data.result[type]
             );

--- a/src/components/address_book_details.vue
+++ b/src/components/address_book_details.vue
@@ -11,13 +11,27 @@
             {{ $t("strings.editAddressBookEntry") }}
           </q-toolbar-title>
 
-          <q-btn v-if="mode == 'edit'" flat no-ripple :label="$t('buttons.cancel')" @click="cancelEdit()" />
-          <q-btn class="q-ml-sm" color="primary" :label="$t('buttons.save')" @click="save()" />
+          <q-btn
+            v-if="mode == 'edit'"
+            flat
+            no-ripple
+            :label="$t('buttons.cancel')"
+            @click="cancelEdit()"
+          />
+          <q-btn
+            class="q-ml-sm"
+            color="primary"
+            :label="$t('buttons.save')"
+            @click="save()"
+          />
         </q-toolbar>
       </q-header>
       <q-page-container>
         <div class="address-book-modal q-mx-md">
-          <LokiField :label="$t('fieldLabels.address')" :error="$v.newEntry.address.$error">
+          <LokiField
+            :label="$t('fieldLabels.address')"
+            :error="$v.newEntry.address.$error"
+          >
             <q-input
               v-model.trim="newEntry.address"
               :placeholder="address_placeholder"
@@ -35,21 +49,11 @@
             />
           </LokiField>
           <LokiField :label="$t('fieldLabels.name')">
-            <q-input v-model.trim="newEntry.name" :dark="theme == 'dark'" borderless dense />
-          </LokiField>
-          <LokiField :label="$t('fieldLabels.paymentId')" :error="$v.newEntry.payment_id.$error" optional>
-            <!-- TODO: count should be 16 or 64 after rpc updated -->
             <q-input
-              v-model.trim="newEntry.payment_id"
-              :placeholder="
-                $t('placeholders.hexCharacters', {
-                  count: '64'
-                })
-              "
+              v-model.trim="newEntry.name"
               :dark="theme == 'dark'"
               borderless
               dense
-              @blur="$v.newEntry.payment_id.$touch"
             />
           </LokiField>
           <LokiField :label="$t('fieldLabels.notes')" optional>
@@ -82,8 +86,20 @@
           <q-toolbar-title>
             {{ $t("strings.addressBookDetails") }}
           </q-toolbar-title>
-          <q-btn class="q-mr-sm" flat no-ripple :disable="!is_ready" :label="$t('buttons.edit')" @click="edit()" />
-          <q-btn color="primary" :disabled="view_only" :label="$t('buttons.sendCoins')" @click="sendToAddress" />
+          <q-btn
+            class="q-mr-sm"
+            flat
+            no-ripple
+            :disable="!is_ready"
+            :label="$t('buttons.edit')"
+            @click="edit()"
+          />
+          <q-btn
+            color="primary"
+            :disabled="view_only"
+            :label="$t('buttons.sendCoins')"
+            @click="sendToAddress"
+          />
         </q-toolbar>
       </q-header>
       <q-page-container>
@@ -92,16 +108,26 @@
             <AddressHeader
               :address="entry.address"
               :title="entry.name"
-              :payment_id="entry.payment_id"
-              :extra="entry.description ? $t('strings.notes') + ': ' + entry.description : ''"
+              :extra="
+                entry.description
+                  ? $t('strings.notes') + ': ' + entry.description
+                  : ''
+              "
             />
 
             <div class="q-mt-lg">
               <div class="non-selectable">
                 <q-icon name="history" size="24px" />
-                <span class="vertical-middle q-ml-xs">{{ $t("strings.recentTransactionsWithAddress") }}</span>
+                <span class="vertical-middle q-ml-xs">{{
+                  $t("strings.recentTransactionsWithAddress")
+                }}</span>
               </div>
-              <TxList :key="entry.address" type="all_in" :limit="5" :to-outgoing-address="entry.address" />
+              <TxList
+                :key="entry.address"
+                type="all_in"
+                :limit="5"
+                :to-outgoing-address="entry.address"
+              />
             </div>
           </template>
         </div>
@@ -115,7 +141,7 @@ import { mapState } from "vuex";
 import AddressHeader from "components/address_header";
 import TxList from "components/tx_list";
 import LokiField from "components/loki_field";
-import { payment_id, address } from "src/validators/common";
+import { address } from "src/validators/common";
 import { required } from "vuelidate/lib/validators";
 export default {
   name: "AddressBookDetails",
@@ -132,7 +158,6 @@ export default {
       newEntry: {
         index: false,
         address: "",
-        payment_id: "",
         name: "",
         description: "",
         starred: false
@@ -164,8 +189,7 @@ export default {
               .catch(() => resolve(false));
           });
         }
-      },
-      payment_id: { payment_id }
+      }
     }
   },
   methods: {
@@ -177,15 +201,6 @@ export default {
           type: "negative",
           timeout: 1000,
           message: this.$t("notification.errors.invalidAddress")
-        });
-        return;
-      }
-
-      if (this.$v.newEntry.payment_id.$error) {
-        this.$q.notify({
-          type: "negative",
-          timeout: 1000,
-          message: this.$t("notification.errors.invalidPaymentId")
         });
         return;
       }
@@ -202,8 +217,7 @@ export default {
       this.$router.replace({
         path: "send",
         query: {
-          address: this.entry.address,
-          payment_id: this.entry.payment_id
+          address: this.entry.address
         }
       });
     },
@@ -217,7 +231,6 @@ export default {
       this.newEntry = {
         index: false,
         address: "",
-        payment_id: "",
         name: "",
         description: "",
         starred: false
@@ -233,7 +246,6 @@ export default {
       this.newEntry = {
         index: false,
         address: "",
-        payment_id: "",
         name: "",
         description: "",
         starred: false

--- a/src/components/address_header.vue
+++ b/src/components/address_header.vue
@@ -7,15 +7,27 @@
           {{ address }}
         </q-item-section>
         <q-item-section v-if="showCopy" side>
-          <q-btn ref="copy" color="primary" padding="xs" size="sm" icon="file_copy" @click="copyAddress">
-            <q-tooltip anchor="center left" self="center right" :offset="[5, 10]">
+          <q-btn
+            ref="copy"
+            color="primary"
+            padding="xs"
+            size="sm"
+            icon="file_copy"
+            @click="copyAddress"
+          >
+            <q-tooltip
+              anchor="center left"
+              self="center right"
+              :offset="[5, 10]"
+            >
               {{ $t("menuItems.copyAddress") }}
             </q-tooltip>
           </q-btn>
         </q-item-section>
       </q-item-label>
-      <q-item-label v-if="paymentId" header>{{ $t("fieldLabels.paymentId") }}: {{ paymentId }}</q-item-label>
-      <q-item-label v-if="extra" header class="extra non-selectable">{{ extra }}</q-item-label>
+      <q-item-label v-if="extra" header class="extra non-selectable">{{
+        extra
+      }}</q-item-label>
     </q-item-section>
     <ContextMenu :menu-items="menuItems" @copyAddress="copyAddress" />
   </div>
@@ -39,11 +51,6 @@ export default {
       type: String,
       required: true
     },
-    paymentId: {
-      type: String,
-      required: false,
-      default: undefined
-    },
     extra: {
       type: String,
       required: false,
@@ -56,7 +63,9 @@ export default {
     }
   },
   data() {
-    const menuItems = [{ action: "copyAddress", i18n: "menuItems.copyAddress" }];
+    const menuItems = [
+      { action: "copyAddress", i18n: "menuItems.copyAddress" }
+    ];
     return {
       menuItems
     };
@@ -67,31 +76,11 @@ export default {
         this.$refs.copy.$el.blur();
       }
       clipboard.writeText(this.address);
-      if (this.paymentId) {
-        this.$q
-          .dialog({
-            title: this.$t("dialog.copyAddress.title"),
-            message: this.$t("dialog.copyAddress.message"),
-            ok: {
-              label: this.$t(`dialog.copyAddress.ok`)
-            }
-          })
-          .onDismiss(() => null)
-          .onCancel(() => null)
-          .onOk(() => {
-            this.$q.notify({
-              type: "positive",
-              timeout: 1000,
-              message: this.$t("notification.positive.addressCopied")
-            });
-          });
-      } else {
-        this.$q.notify({
-          type: "positive",
-          timeout: 1000,
-          message: this.$t("notification.positive.addressCopied")
-        });
-      }
+      this.$q.notify({
+        type: "positive",
+        timeout: 1000,
+        message: this.$t("notification.positive.addressCopied")
+      });
     }
   }
 };

--- a/src/pages/wallet/addressbook.vue
+++ b/src/pages/wallet/addressbook.vue
@@ -1,24 +1,31 @@
 <template>
   <q-page class="address-book">
-    <div class="header row q-pt-md q-pb-xs q-mx-md q-mb-none items-center non-selectable">
+    <div
+      class="header row q-pt-md q-pb-xs q-mx-md q-mb-none items-center non-selectable"
+    >
       {{ $t("titles.addressBook") }}
     </div>
 
     <template v-if="address_book_combined.length">
       <q-list link no-border :dark="theme == 'dark'" class="loki-list">
         <q-item
-          v-for="entry in address_book_combined"
-          :key="`${entry.address}-${entry.name}-${entry.payment_id}`"
+          v-for="(entry, index) in address_book_combined"
+          :key="`${entry.address}-${entry.name}-${index}`"
           class="loki-list-item"
           @click.native="details(entry)"
         >
           <q-item-section>
             <q-item-label class="ellipsis">{{ entry.address }}</q-item-label>
-            <q-item-label class="non-selectable" caption>{{ entry.name }}</q-item-label>
+            <q-item-label class="non-selectable" caption>{{
+              entry.name
+            }}</q-item-label>
           </q-item-section>
           <q-item-section side>
             <q-item-label>
-              <q-icon size="24px" :name="entry.starred ? 'star' : 'star_border'" />
+              <q-icon
+                size="24px"
+                :name="entry.starred ? 'star' : 'star_border'"
+              />
               <q-btn
                 color="secondary"
                 style="margin-left: 10px;"
@@ -72,7 +79,8 @@ export default {
     theme: state => state.gateway.app.config.appearance.theme,
     view_only: state => state.gateway.wallet.info.view_only,
     address_book: state => state.gateway.wallet.address_list.address_book,
-    address_book_starred: state => state.gateway.wallet.address_list.address_book_starred,
+    address_book_starred: state =>
+      state.gateway.wallet.address_list.address_book_starred,
     address_book_combined() {
       const starred = this.address_book_starred.map(a => ({
         ...a,
@@ -97,38 +105,17 @@ export default {
       this.$router.replace({
         path: "send",
         query: {
-          address: address.address,
-          payment_id: address.payment_id
+          address: address.address
         }
       });
     },
     copyAddress(entry) {
       clipboard.writeText(entry.address);
-      if (entry.payment_id) {
-        this.$q
-          .dialog({
-            title: this.$t("dialog.copyAddress.title"),
-            message: this.$t("dialog.copyAddress.message"),
-            ok: {
-              label: this.$t("dialog.buttons.ok")
-            }
-          })
-          .onDismiss(() => null)
-          .onCancel(() => null)
-          .onOk(() => {
-            this.$q.notify({
-              type: "positive",
-              timeout: 1000,
-              message: this.$t("notification.positive.addressCopied")
-            });
-          });
-      } else {
-        this.$q.notify({
-          type: "positive",
-          timeout: 1000,
-          message: this.$t("notification.positive.addressCopied")
-        });
-      }
+      this.$q.notify({
+        type: "positive",
+        timeout: 1000,
+        message: this.$t("notification.positive.addressCopied")
+      });
     }
   }
 };

--- a/src/validators/address_tools.js
+++ b/src/validators/address_tools.js
@@ -1971,9 +1971,6 @@ var cnUtilGen = function(initConfig) {
         NONCE: '02',
         MERGE_MINING: '03'
     };
-    var TX_EXTRA_NONCE_TAGS = {
-        PAYMENT_ID: '00'
-    };
     var KEY_SIZE = 32;
     var STRUCT_SIZES = {
         GE_P3: 160,


### PR DESCRIPTION
Payment ids are no longer used on addresses. This issue caused a rejected promise, in a `Promise.all()`, causing other things to break, like transactions not being listed.