### PR TITLE
Remove payment id from sending tx

### DIFF
--- a/src-electron/main-process/modules/wallet-rpc.js
+++ b/src-electron/main-process/modules/wallet-rpc.js
@@ -336,7 +336,6 @@ export class WalletRPC {
           params.password,
           params.amount,
           params.address,
-          params.payment_id,
           params.priority,
           !!params.isSweepAll
         );
@@ -1557,7 +1556,7 @@ export class WalletRPC {
   // prepares params and provides a "confirm" popup to allow the user to check
   // send address and tx fees before sending
   // isSweepAll refers to if it's the sweep from service nodes page
-  transfer(password, amount, address, payment_id, priority, isSweepAll) {
+  transfer(password, amount, address, priority, isSweepAll) {
     const cryptoCallback = (err, password_hash) => {
       if (err) {
         this.sendGateway("set_tx_status", {
@@ -1598,10 +1597,6 @@ export class WalletRPC {
         do_not_relay: true,
         get_tx_metadata: true
       };
-
-      if (payment_id) {
-        params.payment_id = payment_id;
-      }
 
       // for updating state on the correct page
       const gatewayEndpoint = isSweepAll
@@ -2084,21 +2079,6 @@ export class WalletRPC {
             );
           }
         });
-
-        for (let i = 0; i < wallet.transactions.tx_list.length; i++) {
-          if (/^0*$/.test(wallet.transactions.tx_list[i].payment_id)) {
-            wallet.transactions.tx_list[i].payment_id = "";
-          } else if (
-            /^0*$/.test(wallet.transactions.tx_list[i].payment_id.substring(16))
-          ) {
-            wallet.transactions.tx_list[
-              i
-            ].payment_id = wallet.transactions.tx_list[i].payment_id.substring(
-              0,
-              16
-            );
-          }
-        }
 
         wallet.transactions.tx_list.sort(function(a, b) {
           if (a.timestamp < b.timestamp) return 1;

--- a/src/components/service_node/service_node_staking.vue
+++ b/src/components/service_node/service_node_staking.vue
@@ -256,7 +256,6 @@ export default {
             this.newTx = {
               amount: 0,
               address: "",
-              payment_id: "",
               // blink
               priority: 5,
               address_book: {

--- a/src/components/tx_details.vue
+++ b/src/components/tx_details.vue
@@ -7,8 +7,18 @@
           <q-toolbar-title>
             {{ $t("titles.transactionDetails") }}
           </q-toolbar-title>
-          <q-btn flat class="q-mr-sm" :label="$t('buttons.showTxDetails')" @click="showTxDetails" />
-          <q-btn v-if="can_open" color="primary" :label="$t('buttons.viewOnExplorer')" @click="openExplorer" />
+          <q-btn
+            flat
+            class="q-mr-sm"
+            :label="$t('buttons.showTxDetails')"
+            @click="showTxDetails"
+          />
+          <q-btn
+            v-if="can_open"
+            color="primary"
+            :label="$t('buttons.viewOnExplorer')"
+            @click="openExplorer"
+          />
         </q-toolbar>
       </q-header>
       <q-page-container>
@@ -111,6 +121,7 @@
           </h6>
           <p class="monospace break-all">{{ tx.txid }}</p>
 
+          <!-- Deprecated, but leave this for old transactions -->
           <h6 class="q-mt-xs q-mb-none text-weight-light">
             {{ $t("strings.paymentID") }}
           </h6>
@@ -129,10 +140,17 @@
               </q-item>
               <q-item class="q-px-none">
                 <q-item-label>
-                  <q-item-label class="non-selectable">{{ in_tx_address_used.address_index_text }}</q-item-label>
-                  <q-item-label class="monospace ellipsis">{{ in_tx_address_used.address }}</q-item-label>
+                  <q-item-label class="non-selectable">{{
+                    in_tx_address_used.address_index_text
+                  }}</q-item-label>
+                  <q-item-label class="monospace ellipsis">{{
+                    in_tx_address_used.address
+                  }}</q-item-label>
                 </q-item-label>
-                <ContextMenu :menu-items="menuItems" @copyAddress="copyAddress(in_tx_address_used.address)" />
+                <ContextMenu
+                  :menu-items="menuItems"
+                  @copyAddress="copyAddress(in_tx_address_used.address)"
+                />
               </q-item>
             </q-list>
           </div>
@@ -147,19 +165,32 @@
                 }}:
               </q-item>
               <template v-if="out_destinations">
-                <q-item v-for="destination in out_destinations" :key="destination.address" class="q-px-none">
+                <q-item
+                  v-for="destination in out_destinations"
+                  :key="destination.address"
+                  class="q-px-none"
+                >
                   <q-item-label>
                     <q-item-label>{{ destination.name }}</q-item-label>
-                    <q-item-label class="monospace ellipsis">{{ destination.address }}</q-item-label>
-                    <q-item-label><FormatLoki :amount="destination.amount"/></q-item-label>
+                    <q-item-label class="monospace ellipsis">{{
+                      destination.address
+                    }}</q-item-label>
+                    <q-item-label
+                      ><FormatLoki :amount="destination.amount"
+                    /></q-item-label>
                   </q-item-label>
-                  <ContextMenu :menu-items="menuItems" @copyAddress="copyAddress(destination.address)" />
+                  <ContextMenu
+                    :menu-items="menuItems"
+                    @copyAddress="copyAddress(destination.address)"
+                  />
                 </q-item>
               </template>
               <template v-else>
                 <q-item class="q-px-none">
                   <q-item-label>
-                    <q-item-label header>{{ $t("strings.destinationUnknown") }}</q-item-label>
+                    <q-item-label header>{{
+                      $t("strings.destinationUnknown")
+                    }}</q-item-label>
                   </q-item-label>
                 </q-item>
               </template>
@@ -204,7 +235,9 @@ export default {
     ContextMenu
   },
   data() {
-    const menuItems = [{ action: "copyAddress", i18n: "menuItems.copyAddress" }];
+    const menuItems = [
+      { action: "copyAddress", i18n: "menuItems.copyAddress" }
+    ];
     return {
       isVisible: false,
       txNotes: "",
@@ -215,6 +248,7 @@ export default {
         fee: 0,
         height: 0,
         note: "",
+        // deprecated, but leave for older txs
         payment_id: "",
         subaddr_index: { major: 0, minor: 0 },
         timestamp: 0,
@@ -233,7 +267,9 @@ export default {
     },
     in_tx_address_used(state) {
       let i;
-      let used_addresses = state.gateway.wallet.address_list.primary.concat(state.gateway.wallet.address_list.used);
+      let used_addresses = state.gateway.wallet.address_list.primary.concat(
+        state.gateway.wallet.address_list.used
+      );
       for (i = 0; i < used_addresses.length; i++) {
         if (used_addresses[i].address_index == this.tx.subaddr_index.minor) {
           let address_index_text = "";

--- a/src/pages/wallet/send.vue
+++ b/src/pages/wallet/send.vue
@@ -75,28 +75,6 @@
           </LokiField>
         </div>
 
-        <!-- Payment ID -->
-        <div class="col q-mt-sm">
-          <LokiField
-            :label="$t('fieldLabels.paymentId')"
-            :error="$v.newTx.payment_id.$error"
-            optional
-          >
-            <q-input
-              v-model.trim="newTx.payment_id"
-              :dark="theme == 'dark'"
-              :placeholder="
-                $t('placeholders.hexCharacters', {
-                  count: '16 or 64'
-                })
-              "
-              borderless
-              dense
-              @blur="$v.newTx.payment_id.$touch"
-            />
-          </LokiField>
-        </div>
-
         <!-- Notes -->
         <div class="col q-mt-sm">
           <LokiField :label="$t('fieldLabels.notes')" optional>
@@ -171,7 +149,7 @@
 <script>
 import { mapState } from "vuex";
 import { required, decimal } from "vuelidate/lib/validators";
-import { payment_id, address, greater_than_zero } from "src/validators/common";
+import { address, greater_than_zero } from "src/validators/common";
 import LokiField from "components/loki_field";
 import WalletPassword from "src/mixins/wallet_password";
 import ConfirmDialogMixin from "src/mixins/confirm_dialog_mixin";
@@ -196,7 +174,6 @@ export default {
       newTx: {
         amount: 0,
         address: "",
-        payment_id: "",
         priority: priorityOptions[0].value,
         address_book: {
           save: false,
@@ -250,8 +227,7 @@ export default {
               .catch(() => resolve(false));
           });
         }
-      },
-      payment_id: { payment_id }
+      }
     }
   },
   watch: {
@@ -277,7 +253,6 @@ export default {
             this.newTx = {
               amount: 0,
               address: "",
-              payment_id: "",
               priority: this.priorityOptions[0].value,
               address_book: {
                 save: false,
@@ -315,7 +290,6 @@ export default {
   methods: {
     autoFill: function(info) {
       this.newTx.address = info.address;
-      this.newTx.payment_id = info.payment_id;
     },
     buildDialogFieldsSend(txData) {
       // build using mixin method
@@ -331,7 +305,6 @@ export default {
       const { name, description, save } = this.newTx.address_book;
       const addressSave = {
         address: this.newTx.address,
-        payment_id: this.newTx.payment_id,
         address_book: {
           description,
           name,
@@ -399,15 +372,6 @@ export default {
           type: "negative",
           timeout: 1000,
           message: this.$t("notification.errors.invalidAddress")
-        });
-        return;
-      }
-
-      if (this.$v.newTx.payment_id.$error) {
-        this.$q.notify({
-          type: "negative",
-          timeout: 1000,
-          message: this.$t("notification.errors.invalidPaymentId")
         });
         return;
       }

--- a/src/validators/common.js
+++ b/src/validators/common.js
@@ -3,13 +3,6 @@ export const greater_than_zero = input => {
   return input > 0;
 };
 
-export const payment_id = input => {
-  return (
-    input.length === 0 ||
-    (/^[0-9A-Fa-f]+$/.test(input) && (input.length == 64 || input.length == 16))
-  );
-};
-
 export const privkey = input => {
   return (
     input.length === 0 || (/^[0-9A-Fa-f]+$/.test(input) && input.length == 64)


### PR DESCRIPTION
Payment ids are no longer supported by the RPC, attempting to use in the GUI just throws an RPC error. Thus, it is being removed.